### PR TITLE
aligned hero h1 to left

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -160,6 +160,10 @@ h1 {
   text-align: center;
 }
 
+.hero-content > h1 {
+  text-align: left;
+}
+
 /* small screen */
 @media screen and (max-width: 800px) {
   .hero {


### PR DESCRIPTION
❓**What**: align h1 in hero to the left

🧠**Why?**: so that it aligns with the subheader and buttons below

👨‍💻**How?**: CSS

# Checklist:
Have checked for the following:
- [X] The website still builds correctly, and you can view it using `mkdocs serve`.
- [X] There are no new "warnings" from mkdocs
- [X] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [X] Spelling errors
- [X] Consistent capitalization
- [X] Consistent numbers
- [X] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [X] Code snippets don't work
- [X] Images not working
- [X] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings