### PR TITLE
make carousel rotate a more legible direction

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -193,7 +193,7 @@ then resetting.
  
 @keyframes swirl {   
   from {
-    transform: rotateY(-360deg);
+    transform: rotateY(360deg);
   }
   to {
     transform: rotateY(0deg);


### PR DESCRIPTION
<!-- 
- Pull request title follows this format "SH NV-1234 Solves this problem":
    - Initials of author
    - associated Jira ticket number
    - brief description
- Choose appropriate labels
- Use the "development" sidebar option to indicate if this closes any open issues, etc.
-->
# Description
<!-- 
In the body of the pull request, provide a description following the "What, Why, How" approach. 

You could also add a gif using the "gifs for GitHub" Chrome extension: https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep/related?hl=en
-->

❓**What**: make the carousel rotate in the opposite direction

🧠**Why?**: more legible when it moves in the same direction as we read 

👨‍💻**How?**: changing rotation css 

# Checklist:
Have checked for the following:
- [x] The website still builds correctly, and you can view it using `mkdocs serve`.
- [x] There are no new "warnings" from mkdocs
- [x] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [x] Spelling errors
- [x] Consistent capitalization
- [x] Consistent numbers
- [x] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [x] Code snippets don't work
- [x] Images not working
- [x] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings