### PR TITLE
add content review step to contribution guidance

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -15,6 +15,7 @@ If you want to contribute to our resources:
 3. Create a new branch: `git checkout -b my-branch-name`
 4. Make your change
 5. Check how your change looks on our website by hosting the website locally (follow [the steps below](#contribute-to-nhs-england-data-science-website) on how to do this)
+6. Content Review (follow the [instructions](#content-review))
 6. Push to your fork and [submit a pull request][pr]
 
 Your pull request will then be reviewed. You may receive some feedback and suggested changes before it can be approved and your pull request merged.
@@ -55,6 +56,9 @@ To add a new file to the repository and website:
 
 The website currently uses the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/) theme. This sets the layout, colour, font, search bar, header, footer, navigation bar and contents. You can follow the documentation to make any changes (e.g. change the [colour scheme](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/)) as it is simple to use and also easy to overwrite. There is a separate stylesheet, [extra.css](./docs/stylesheets/extra.css), which is used to overwrite the colours, fonts and some of the sizing for some elements.
 Here is a good [cheat sheet](https://yakworks.github.io/docmark/cheat-sheet/) for what features can be used in MkDocs and also interesting features in [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/reference/).
+
+### Content Review
+Prior to making a pull request, ensure that, if the changes involve a change or addition of content (rather than technical or spelling changes) to the site, you have gone through a content review as outlined [here](https://nhsd-confluence.digital.nhs.uk/display/DAT/Website+Gateway). This is to ensure that no sensitive or policy content goes into your PR, as whilst PRs aren't live on the website they are still public (as the repo is public). 
 
 #### Blog / Article
 


### PR DESCRIPTION
<!-- 
- Pull request title follows this format "SH NV-1234 Solves this problem":
    - Initials of author
    - associated Jira ticket number
    - brief description
- Choose appropriate labels
- Use the "development" sidebar option to indicate if this closes any open issues, etc.
-->
# Description
<!-- 
In the body of the pull request, provide a description following the "What, Why, How" approach. 

You could also add a gif using the "gifs for GitHub" Chrome extension: https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep/related?hl=en
-->

❓**What**: add content review to contribution guidance

🧠**Why?**: we have added a new step to the contribution process to make sure people dont make sensitive content public

👨‍💻**How?**: adding it to the CONTRIBUTE.md page and linking to the confluence guidance. 

# Checklist:
Have checked for the following:
- [x] The website still builds correctly, and you can view it using `mkdocs serve`.
- [x] There are no new "warnings" from mkdocs
- [ ] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [x] Spelling errors
- [x] Consistent capitalization
- [x] Consistent numbers
- [x] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [x] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings