### PR TITLE
HS consistent capitalisation of role titles

### DIFF
--- a/docs/PhDInterns.md
+++ b/docs/PhDInterns.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-# PhD Internership Scheme
+# PhD Internship Scheme
 
 Our internships are aimed at current PhD students looking for an industrial placement of around five months with the right to work in the UK. The projects are focussed on innovation, in particular around getting the most value out of NHS data.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -24,7 +24,7 @@ We are the [NHS England](https://www.england.nhs.uk/) Data Science Team.
 
 </div>
 
-## How are we different from analytical teams?
+## How We Are Different From Analytical Teams
 
 <div class="grid cards" markdown>
 
@@ -54,7 +54,7 @@ We are the [NHS England](https://www.england.nhs.uk/) Data Science Team.
 
 </div>
 
-## Our missions
+## Our Missions
 
 === "Deliver"
     <h3 style="text-align: center;"> **Deliver problem led data science products to commissioners.** </h3>
@@ -72,7 +72,7 @@ We are the [NHS England](https://www.england.nhs.uk/) Data Science Team.
     <h3 style="text-align: center;"> **Devise a great place to work where group work solves great problems​​​​.​**</h3>
 
 ## Our Members
-??? "Our members"
+??? "Our Members"
     <table id="myTable" style="width:100%;">
         <div class="flex flex-basis">
         <select id="columnToSearch">

--- a/docs/useful_links.md
+++ b/docs/useful_links.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-# Useful links
+# Useful Links
 
 This is a list, mostly copied from [RAP guidance pages](https://harrietrs.github.io/rap-community-of-practice/useful_links/) and shows a range of resources throughout the Government and other areas. Let us know if you have any links to useful information, resources or guides that could be added to the list.
 
@@ -47,7 +47,7 @@ The [Turing Way](https://the-turing-way.netlify.app/index.html#) have also produ
 
 - The [NHS Digital Github](https://github.com/NHSDigital/data-analytics-services) contains code shared from NHS Digital (and NHS England) projects. Well worth a look.
 
-## Community spaces
+## Community Spaces
 
 There are several slack channels that discuss RAP and related topics: the govdatascience.slack.com RAP channel, the NHS-R community, and the NHS-pycom community
 We have an MS Teams page (internal to NHS Digital)

--- a/docs/what_is_data_science/Benefits of Data Science in the NHS.md
+++ b/docs/what_is_data_science/Benefits of Data Science in the NHS.md
@@ -1,6 +1,6 @@
 # Benefits of Data Science in the NHS
 
-Data Science can be helpful in [solving a number of problems](./index.md). Specifically, this could lead to benefits such as:
+Data science can be helpful in [solving a number of problems](./index.md). Specifically, this could lead to benefits such as:
 
 - **better resource planning** (e.g. [improving bed allocation using AI](../our_work/bed-allocation.md))
 - **increased responsiveness to demand and seasonal pressures** (e.g. A&E demand prediction)

--- a/docs/what_is_data_science/How you can learn Data Science.md
+++ b/docs/what_is_data_science/How you can learn Data Science.md
@@ -1,6 +1,6 @@
 # How you can learn Data Science
 
-Data Science isn't just for Data Scientists! As a profession, we're passionate about sharing these skills and techniques.
+Data science isn't just for data scientists! As a profession, we're passionate about sharing these skills and techniques.
 
 For this purpose we've put together a **monthly newsletter** with valuable **insights**, **training opportunities** and **events** for people interested in learning more about the various aspects of data science, further developing their skills, and progressing in their career:
 
@@ -12,7 +12,7 @@ For this purpose we've put together a **monthly newsletter** with valuable **ins
         
     The newsletter is targeted towards members of the NHS England Data Science team, so some links may only be accessible to those with the necessary login credentials, however the newsletter and its archive are available for all at the link above.
 
-Through [AnalystX] we also support the [NHS Data Science community](https://data-science-community.analystx.uk/) which is the home of spreading data science knowledge within the NHS.
+Through [AnalystX] we also support the [NHS Data Science Community](https://data-science-community.analystx.uk/) which is the home of spreading data science knowledge within the NHS.
 
 You can also learn a lot about data science by simply getting to know the wider cross-government/health community:
 

--- a/docs/what_is_data_science/How you can learn Data Science.md
+++ b/docs/what_is_data_science/How you can learn Data Science.md
@@ -1,4 +1,4 @@
-# How you can learn Data Science
+# How You Can Learn Data Science
 
 Data science isn't just for data scientists! As a profession, we're passionate about sharing these skills and techniques.
 

--- a/docs/what_is_data_science/index.md
+++ b/docs/what_is_data_science/index.md
@@ -16,7 +16,7 @@ Some examples of the kinds of problems data science can help with are:
 
 **Artificial Intelligence** and **Machine Learning** are techniques which are widely associated with data science and data scientists, and which can be applied to basically any of the problems listed above. See also this article on the ["Seven Patterns of AI"](https://www.forbes.com/sites/cognitiveworld/2019/09/17/the-seven-patterns-of-ai/?sh=448cf51812d0).
 
-??? info "How do data scientists differ from analysts and Data engineers?"
-    Data science can be quite hard to pin down, as it covers a lot of different techniques, and problems, and data scientists themselves often have a lot of overlap with analysts and Data engineers. Analysts and engineers might well use data science techniques in their work!
+??? info "How do data scientists differ from analysts and data engineers?"
+    Data science can be quite hard to pin down, as it covers a lot of different techniques, and problems, and data scientists themselves often have a lot of overlap with analysts and data engineers. Analysts and engineers might well use data science techniques in their work!
 
     However, generally data scientists are more focused on looking ahead, embracing and exploiting new techniques across a range of different types of data, e.g. unstructured data, such as text, images, audio.

--- a/docs/what_is_data_science/index.md
+++ b/docs/what_is_data_science/index.md
@@ -8,11 +8,11 @@ Data scientists will often use programming languages such as Python and R (among
 
 Some examples of the kinds of problems data science can help with are:
 
-- **getting more value out of unstructured data** (e.g. text, images, audio) through "Natural Language Processing", "Neural Networks" and recently "Large Language Models" (e.g. ChatGPT).
-- **modelling systems and forecasting** (though compared with statisticians and economists, this tends to be more empirical, requiring more focus on evaluation)
-- **explaining existing models and their performance** - communication is a key pillar of data science: making the complex understandable to everyone else.
-- **enriching and transforming data**, such as through linkage, feature engineering, artificial and synthetic data generation
-- **classification and regression** - that is saying what something is, or if something will or won't happen, and/or quantifying something unknown.
+- **Getting more value out of unstructured data** (e.g. text, images, audio) through "Natural Language Processing", "Neural Networks" and recently "Large Language Models" (e.g. ChatGPT).
+- **Modelling systems and forecasting** (though compared with statisticians and economists, this tends to be more empirical, requiring more focus on evaluation).
+- **Explaining existing models and their performance** - communication is a key pillar of data science: making the complex understandable to everyone else.
+- **Enriching and transforming data**, such as through linkage, feature engineering, artificial and synthetic data generation.
+- **Classification and regression** - that is saying what something is, or if something will or won't happen, and/or quantifying something unknown.
 
 **Artificial Intelligence** and **Machine Learning** are techniques which are widely associated with data science and data scientists, and which can be applied to basically any of the problems listed above. See also this article on the ["Seven Patterns of AI"](https://www.forbes.com/sites/cognitiveworld/2019/09/17/the-seven-patterns-of-ai/?sh=448cf51812d0).
 

--- a/docs/what_is_data_science/index.md
+++ b/docs/what_is_data_science/index.md
@@ -4,7 +4,7 @@ Quoting the [Digital, Data and Technology (DDaT) Capability Framework](https://d
 
 > Data science is a broad and fast-moving field spanning maths, statistics, software engineering and communications. Data scientists will often work as part of a multidisciplinary team, using data and analytics to inform and achieve organisational goals.
 
-Specifically, this means that often data scientists use programming languages like Python and R (though there are others too!) to solve problems within the business, or inform about courses of action, working with other colleagues such as analysts and data engineers, in particular.
+Data scientists will often use programming languages such as Python and R (among others!) to solve problems within a business or to inform decisions, working with other colleagues such as analysts and data engineers.
 
 Some examples of the kinds of problems data science can help with are:
 
@@ -14,9 +14,9 @@ Some examples of the kinds of problems data science can help with are:
 - **enriching and transforming data**, such as through linkage, feature engineering, artificial and synthetic data generation
 - **classification and regression** - that is saying what something is, or if something will or won't happen, and/or quantifying something unknown.
 
-**Artificial Intelligence** and **Machine Learning** are techniques which are widely associated with Data Science and Data Scientists, and which can be applied to basically any of the problems listed above. See also this article on the ["Seven Patterns of AI"](https://www.forbes.com/sites/cognitiveworld/2019/09/17/the-seven-patterns-of-ai/?sh=448cf51812d0).
+**Artificial Intelligence** and **Machine Learning** are techniques which are widely associated with data science and data scientists, and which can be applied to basically any of the problems listed above. See also this article on the ["Seven Patterns of AI"](https://www.forbes.com/sites/cognitiveworld/2019/09/17/the-seven-patterns-of-ai/?sh=448cf51812d0).
 
-??? info "How does Data Scientists differ from Analysts and Data engineers?"
-    Data Science can be quite hard to pin down, as it covers a lot of different techniques, and problems, and data scientists themselves often have a lot of overlap with Analysts and Data Engineers. Analysts and Engineers might well use data science techniques in their work!
+??? info "How do data scientists differ from analysts and Data engineers?"
+    Data science can be quite hard to pin down, as it covers a lot of different techniques, and problems, and data scientists themselves often have a lot of overlap with analysts and Data engineers. Analysts and engineers might well use data science techniques in their work!
 
-    However, generally, data scientists are slightly more focussed on looking ahead, embracing and exploiting new techniques, e.g. unstructured data, such as text, images, audio.
+    However, generally data scientists are more focused on looking ahead, embracing and exploiting new techniques across a range of different types of data, e.g. unstructured data, such as text, images, audio.


### PR DESCRIPTION
# Description
❓**What**:
Includes data scientists, analysts, engineers. Also corrects 'Data Science' to only be used in titles.

Also suggests a few minor phrasing changes to the 'What is Data Science?' page, and makes titles in the 'about' section consistently capitalised.

This PR also corrects a spelling error on the phd interns page.

🧠**Why?**:
Improves readability.

# Checklist:
Have checked for the following:
- [x] The website still builds correctly, and you can view it using `mkdocs serve`.
- [X] There are no new "warnings" from mkdocs
- [X] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [X] Spelling errors
- [X] Consistent capitalization
- [X] Consistent numbers
- [X] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [X] Code snippets don't work
- [X] Images not working
- [X] Links not working

## Where it was tested
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive