### PR TITLE
fix homepage images

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -306,6 +306,8 @@
     height: 144px;
     border-radius: 10px;
     border: 2px solid black;
+    object-fit: contain;
+    background-color: white;
 }
 
 .tile:focus,


### PR DESCRIPTION
<!-- 
- Pull request title follows this format "SH NV-1234 Solves this problem":
    - Initials of author
    - associated Jira ticket number
    - brief description
- Choose appropriate labels
- Use the "development" sidebar option to indicate if this closes any open issues, etc.
-->
# Description
<!-- 
In the body of the pull request, provide a description following the "What, Why, How" approach. 

You could also add a gif using the "gifs for GitHub" Chrome extension: https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep/related?hl=en
-->

❓**What**: make images not be stretched on homepage tiles

🧠**Why?**: stretching looked bad

👨‍💻**How?**: object-fit: contain;

# Checklist:
Have checked for the following:
- [x] The website still builds correctly, and you can view it using `mkdocs serve`.
- [x] There are no new "warnings" from mkdocs
- [x] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [x] Spelling errors
- [x] Consistent capitalization
- [x] Consistent numbers
- [x] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [x] Code snippets don't work
- [x] Images not working
- [x] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings