### PR TITLE
HS ISSUE 251 updated ai knowledge repository links

### DIFF
--- a/docs/our_work/bed-allocation.md
+++ b/docs/our_work/bed-allocation.md
@@ -16,7 +16,7 @@ A proof-of-concept demonstrator written in Python (backend, virtual hospital, mo
 
 # Case Study
 
-This is a backup of the case study published [here](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101060022/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/improving-hospital-bed-allocation-using-ai/) on the NHS England Transformation Directorate website.
+This is a backup of the case study published [here](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/improving-hospital-bed-allocation-using-ai) on the NHS England Transformation Directorate website.
 
 Kettering General Hospital approached the NHS AI Lab Skunkworks team with a request for support exploring artificial intelligence (AI) to improve bed management. Their vision was to use AI to achieve the “right patient, in the right bed, receiving the right care, at the right time.”
 
@@ -120,7 +120,7 @@ Faculty is an applied AI company that helps build and accelerate an organisation
 Output|Link
 ---|---
 Open Source Code & Documentation|[Github](https://github.com/nhsx/skunkworks-bed-allocation)
-Case Study|[Case Study](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101060022/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/improving-hospital-bed-allocation-using-ai/)
+Case Study|[Case Study](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/improving-hospital-bed-allocation-using-ai)
 Technical report|[PDF](https://github.com/nhsx/skunkworks-bed-allocation/blob/main/docs/NHS_AI_Lab_Skunkworks_Bed_Allocation_Technical_Report.pdf)
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)

--- a/docs/our_work/ct-alignment.md
+++ b/docs/our_work/ct-alignment.md
@@ -16,7 +16,7 @@ A proof-of-concept demonstrator written in Python (user interface, classical com
 
 ## Case Study
 
-This is a backup of the case study published [here](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101055214/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/using-ai-to-identify-tissue-growth-from-ct-scans/) on the NHS England Transformation Directorate website.
+This is a backup of the case study published [here](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/using-ai-to-identify-tissue-growth-from-ct-scans) on the NHS England Transformation Directorate website.
 
 George Eliot Hospital approached the NHS AI Lab Skunkworks team with an idea to use AI to speed up the analysis of computerised tomography (CT) scans.
 
@@ -110,7 +110,7 @@ Roke is a long-established science and engineering organisation, providing AI an
 Output|Link
 ---|---
 Open Source Code & Documentation|[Github](https://github.com/nhsx/skunkworks-ct-alignment-lesion-detection)
-Case Study|[Case Study](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101055214/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/using-ai-to-identify-tissue-growth-from-ct-scans/)
+Case Study|[Case Study](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/using-ai-to-identify-tissue-growth-from-ct-scans)
 Technical report|[PDF](https://github.com/nhsx/skunkworks-ct-alignment-lesion-detection/blob/main/docs/NHS_AI_Lab_Skunkworks_CT_Alignment_Lesion_Detection_Technical_Report.pdf)
 Video walkthrough|[YouTube](http://www.youtube.com/watch?v=QygOnGLcszk)
 

--- a/docs/our_work/data-lens.md
+++ b/docs/our_work/data-lens.md
@@ -18,7 +18,7 @@ A prototype website written in HTML/CSS/JavaScript (frontend), JavaScript (backe
 
 # Case Study
 
-This is a backup of the case study published [here](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101060541/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/data-lens-a-fast-access-data-search-in-multiple-languages/) on the NHS England Transformation Directorate website.
+This is a backup of the case study published [here](https://digital.nhs.uk/services/ai-knowledge-repository/develop-ai/data-lens-a-fast-access-data-search-in-multiple-languages) on the NHS England Transformation Directorate website.
 
 A pilot project for the NHS AI Lab Skunkworks team, Data Lens brings together information about multiple databases, providing a fast-access search in multiple languages
 
@@ -85,7 +85,7 @@ The team brought in metadata from NHS Digital, NHS England and Improvement, Publ
 Output|Link
 ---|---
 Open Source Code & Documentation|[Github](https://github.com/nhsx/skunkworks-data-lens)
-Case Study|[Case Study](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101060541/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/data-lens-a-fast-access-data-search-in-multiple-languages/)
+Case Study|[Case Study](https://digital.nhs.uk/services/ai-knowledge-repository/develop-ai/data-lens-a-fast-access-data-search-in-multiple-languages)
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)
 #

--- a/docs/our_work/long-stay.md
+++ b/docs/our_work/long-stay.md
@@ -18,7 +18,7 @@ A proof-of-concept demonstrator written in Python (machine learning model and ba
 
 ## Info
 
-This is a backup of the case study published [here](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101054858/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/using-machine-learning-to-identify-patients-at-risk-of-long-term-hospital-stays/) on the NHS England Transformation Directorate website.
+This is a backup of the case study published [here](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/using-machine-learning-to-identify-patients-at-risk-of-long-term-hospital-stays) on the NHS England Transformation Directorate website.
 
 ## Case Study
 
@@ -111,7 +111,7 @@ Polygeist, a software company specialising in state-scale analytics, builds worl
 Output|Link
 ---|---
 Open Source Code & Documentation|[Github](https://github.com/nhsx/skunkworks-long-stayer-risk-stratification)
-Case Study|[Case Study](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101054858/https://transform.england.nhs.uk/ai-lab/explore-all-resources/develop-ai/using-machine-learning-to-identify-patients-at-risk-of-long-term-hospital-stays/)
+Case Study|[Case Study](https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/using-machine-learning-to-identify-patients-at-risk-of-long-term-hospital-stays)
 Technical report|On request: [ai-skunkworks@nhsx.nhs.uk](mailto:ai-skunkworks@nhsx.nhs.uk?subject=Request%20for%20NHS_AI_Lab_Skunkworks_Long_Stayer_Risk_Stratification_Technical_Report.pdf)
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)

--- a/docs/our_work/nhs-resolution.md
+++ b/docs/our_work/nhs-resolution.md
@@ -18,7 +18,7 @@ We aimed to prove the value of machine learning in determining insights from the
 
 # Case Study
 
-This is a backup of the case study published [here](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101055118/https://transform.england.nhs.uk/ai-lab/explore-all-resources/understand-ai/using-ai-to-support-nhs-resolution-with-negligence-claims-prediction/) on the NHS England Transformation Directorate website.
+This is a backup of the case study published [here](https://digital.nhs.uk/services/ai-knowledge-repository/develop-ai/using-ai-to-support-nhs-resolution-with-negligence-claims-prediction) on the NHS England Transformation Directorate website.
 
 NHS trusts undertake an enormous number of activities each year (around 240 million in the year 2018 to 2019 according to the [Kings Fund](https://www.kingsfund.org.uk/projects/nhs-in-a-nutshell/NHS-activity)). The vast majority of people receive safe care, however [NHS Resolution](https://resolution.nhs.uk/) received over 15,000 claims for compensation last year on behalf of the NHS in England, which includes hospital trusts and GPs. Although many (almost half the claims in 2018 to 2019) get settled without damages, NHS Resolution figures show that claims can cost the health and care system up to £2.6 billion a year.
 
@@ -101,7 +101,7 @@ Future improvements to both the data and the model would provide a more accurate
 
 Output|Link
 ---|---
-Case Study| [NHSE Transformation Site](https://webarchive.nationalarchives.gov.uk/ukgwa/20241101055118/https://transform.england.nhs.uk/ai-lab/explore-all-resources/understand-ai/using-ai-to-support-nhs-resolution-with-negligence-claims-prediction/)
+Case Study| [NHSE Transformation Site](https://digital.nhs.uk/services/ai-knowledge-repository/develop-ai/using-ai-to-support-nhs-resolution-with-negligence-claims-prediction)
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)
 #


### PR DESCRIPTION
# Description

❓**What**:

Replaces web archive links to case studies to permanent links on the AI Knowledge Repository website.

🧠**Why?**:

Closes #251 

# Checklist:
Have checked for the following:
- [ ] The website still builds correctly, and you can view it using `mkdocs serve`.
- [ ] There are no new "warnings" from mkdocs
- [x] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))? (**need to make a new one specific to NHSE Data Science**)
- [x] Spelling errors
- [x] Consistent capitalization
- [x] Consistent numbers
- [x] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [ ] Links not working
