### PR TITLE
Remove debug console.log from table filter

### DIFF
--- a/docs/javascripts/tablefilter.js
+++ b/docs/javascripts/tablefilter.js
@@ -6,8 +6,7 @@ function tableFilter(table_id, input_id) {
   table = document.getElementById(table_id);
   tr = table.getElementsByTagName("tr");
   const columnSelector = document.getElementById("columnToSearch").value;
-  
-  console.log(columnSelector)
+
   // Loop through all table rows, and hide those who don't match the search query
   const columnNames = ['Name','Role', 'Team', 'Github']
   const columnIndex = columnNames.indexOf(columnSelector)


### PR DESCRIPTION
## Summary
- Removes a leftover `console.log(columnSelector)` that fires on every keystroke in the About page team member search

## Test plan
- [ ] Visit the [About page](https://nhsengland.github.io/datascience/about/), open browser console, type in the filter — no more log spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)