### PR TITLE
Fix 4 broken links caused by markdown encoding issues

### DIFF
--- a/docs/our_work/casestudy-recruitment-shortlisting.md
+++ b/docs/our_work/casestudy-recruitment-shortlisting.md
@@ -28,7 +28,7 @@ There are many ways to define bias depending on whether it is in relation to the
 
 When talking about bias by the predictive model, the model was determined to have shown ‘bias’ if the errors made in prediction were larger than an accepted error rate (which is defined by the person carrying out the work).
 
-Bias can also be identified by looking at integrity of the source data (looking at factors such as the way it was collected) or sufficiency (see [here](https://en.wikipedia.org/wiki/Fairness_(machine_learning)#:~:text=of%20a%20model.%22-,Sufficiency,-%5Bedit%5D)) of the data
+Bias can also be identified by looking at integrity of the source data (looking at factors such as the way it was collected) or sufficiency (see [here](https://en.wikipedia.org/wiki/Fairness_%28machine_learning%29#:~:text=of%20a%20model.%22-,Sufficiency,-%5Bedit%5D)) of the data
 
 ![Graph of the counts and proportions of candidates shortlisted or not shortlisted, by grade and ethnicity.](../images/Recruitment_graph.width-800.png)
 

--- a/docs/our_work/p11_synpathdiabetes.md
+++ b/docs/our_work/p11_synpathdiabetes.md
@@ -23,7 +23,7 @@ Future collaboration around validation and how to apply learning algorithms are 
 | ---- | ---- |
 | Open Source Code & Documentation | [Github](https://github.com/nhsx/SynPath_Diabetes) |
 | Case Study | Awaiting Sign-Off |
-| Technical report | [Here](https://github.com/nhsx/SynPath_Diabetes/blob/main/t2dm/reports/Technical%20Report%20(SynPath%20Diabetes)%20v1.pdf) |
+| Technical report | [Here](https://github.com/nhsx/SynPath_Diabetes/blob/main/t2dm/reports/Technical%20Report%20%28SynPath%20Diabetes%29%20v1.pdf) |
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)
 #

--- a/docs/our_work/p21_synthvae.md
+++ b/docs/our_work/p21_synthvae.md
@@ -25,7 +25,7 @@ Further work will explore the adaption of directed acyclic graphs to control for
 | ---- | ---- |
 | Open Source Code & Documentation | [Github](https://github.com/nhsx/SynthVAE) |
 | Case Study | Awaiting Sign-Off |
-| Technical report | [Here](https://github.com/nhsx/SynthVAE/blob/main/reports/NHSX_SynthVAE%20(2).pdf) |
+| Technical report | [Here](https://github.com/nhsx/SynthVAE/blob/main/reports/NHSX_SynthVAE%20%282%29.pdf) |
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)
 #

--- a/docs/our_work/p51_privconcerns.md
+++ b/docs/our_work/p51_privconcerns.md
@@ -12,7 +12,7 @@ See our blog on this work [here](https://nhsengland.github.io/datascience/articl
 | ---- | ---- |
 | Open Source Code & Documentation | [Code](https://github.com/nhsengland/priv-lm-health) |
 | Case Study | Awaiting Sign-Off |
-| Technical report | [Report](https://github.com/nhsengland/priv-lm-health/blob/main/reports/Healthcare_LLM_Privacy_VS_v1.0.pdf)] |
+| Technical report | [Report](https://github.com/nhsengland/priv-lm-health/blob/main/reports/Healthcare_LLM_Privacy_VS_v1.0.pdf) |
 
 [comment]: <> (The below header stops the title from being rendered (as mkdocs adds it to the page from the "title" attribute) - this way we can add it in the main.html, along with the summary.)
 #


### PR DESCRIPTION
## Summary
- Fix parentheses in PDF URLs that were being truncated by the markdown parser (`(` → `%28`, `)` → `%29`)
- Remove a stray trailing `]` after a URL in p51_privconcerns.md

**Affected pages:**
- [SynPath Diabetes](https://nhsengland.github.io/datascience/our_work/p11_synpathdiabetes/) — technical report link
- [SynthVAE](https://nhsengland.github.io/datascience/our_work/p21_synthvae/) — technical report link
- [Recruitment Shortlisting](https://nhsengland.github.io/datascience/our_work/casestudy-recruitment-shortlisting/) — Wikipedia link
- [Privacy Concerns](https://nhsengland.github.io/datascience/our_work/p51_privconcerns/) — technical report link

## Test plan
- [ ] Click each of the 4 fixed links on the live preview and confirm they resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)