### PR TITLE
Clarify README: mention MkDocs Material, remove duplicate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,9 @@
 >
 > See our other work here: [NHS Digital Analytical Services](https://github.com/NHSDigital/data-analytics-services).
 
-<br>
+This site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and deployed via GitHub Actions to [nhsengland.github.io/datascience](https://nhsengland.github.io/datascience/).
 
-**Welcome to the landing page for Data Science in NHS England.**
-
-Visit our [website](https://nhsengland.github.io/datascience/) for more information about our work!
-
-If you want to contribute (such as making your own project page), [see the guidance here](CONTRIBUTE.md)
-
-[<kbd> <br> Data Science in NHS England <br> </kbd>](https://nhsengland.github.io/datascience/)
+If you want to contribute (such as making your own project page), [see the guidance here](CONTRIBUTE.md).
 
 ## Licence
 


### PR DESCRIPTION
## Summary
- States that the site is built with MkDocs Material and deployed via GitHub Actions
- Removes the redundant double-link to the website (a text URL + a styled `<kbd>` button both pointing to the same place)

Closes #112

## Test plan
- [ ] Check the README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)